### PR TITLE
fix: resolve plugin bugs and improve quality

### DIFF
--- a/src/js/peekabar.js
+++ b/src/js/peekabar.js
@@ -7,13 +7,14 @@
 (function ($) {
   'use strict';
 
+  let _instanceCount = 0;
+
   $.peekABar = function (options) {
-    let that = this,
-      rand = parseInt(Math.random() * 100000000, 0);
+    let that = this;
 
     this.bar = {};
-
     this.settings = {};
+    this._autohideTimer = null;
 
     let defaults = {
       html: 'Your Message Here',
@@ -35,7 +36,7 @@
     };
 
     let init = () => {
-      that.settings = $.extend({}, defaults, options);
+      that.settings = $.extend(true, {}, defaults, options);
       _create();
       _applyCustomSettings();
     };
@@ -46,45 +47,63 @@
           this.bar.html(args.html);
         }
       }
+
+      const duration = that.settings.animation.duration;
+      const onShowDone = () => that.settings.onShow.call(that, args);
+
       switch (this.settings.animation.type) {
         case 'slide':
-          this.bar.slideDown(that.settings.animation.duration);
+          this.bar.slideDown(duration, onShowDone);
           break;
         case 'fade':
-          this.bar.fadeIn(that.settings.animation.duration);
+          this.bar
+            .css('opacity', 0)
+            .show()
+            .animate({ opacity: that.settings.opacity }, duration, onShowDone);
           break;
       }
+
       if (this.settings.autohide) {
-        setTimeout(function () {
+        clearTimeout(this._autohideTimer);
+        this._autohideTimer = setTimeout(() => {
           that.hide();
         }, this.settings.delay);
       }
-      this.settings.onShow.call(this, args);
     };
 
     this.hide = () => {
+      const duration = that.settings.animation.duration;
+      const onHideDone = () => that.settings.onHide.call(that);
+
       switch (this.settings.animation.type) {
         case 'slide':
-          this.bar.slideUp(that.settings.animation.duration);
+          this.bar.slideUp(duration, onHideDone);
           break;
         case 'fade':
-          this.bar.fadeOut(that.settings.animation.duration);
+          this.bar.animate({ opacity: 0 }, duration, () => {
+            that.bar.hide();
+            onHideDone();
+          });
           break;
       }
-      this.settings.onHide.call(this);
+    };
+
+    this.destroy = () => {
+      clearTimeout(that._autohideTimer);
+      that.bar.remove();
     };
 
     let _create = () => {
+      const id = ++_instanceCount;
       that.bar = $('<div></div>')
         .addClass('peek-a-bar')
-        .attr('id', '__peek_a_bar_' + rand);
+        .attr('id', '__peek_a_bar_' + id);
       $('html').append(that.bar);
       that.bar.hide();
     };
 
     let _applyCustomSettings = () => {
       _applyHTML();
-      _applyAutohide();
       _applyPadding();
       _applyBackgroundColor();
       _applyOpacity();
@@ -95,14 +114,6 @@
 
     let _applyHTML = () => {
       that.bar.html(that.settings.html);
-    };
-
-    let _applyAutohide = () => {
-      if (that.settings.autohide) {
-        setTimeout(() => {
-          that.hide();
-        }, that.settings.delay);
-      }
     };
 
     let _applyPadding = () => {
@@ -125,20 +136,18 @@
 
     let _applyPosition = () => {
       switch (that.settings.position) {
-        case 'top':
-          that.bar.css('top', 0);
-          break;
         case 'bottom':
-          that.bar.css('bottom', 0);
+          that.bar.css({ bottom: 0, top: '' });
           break;
+        case 'top':
         default:
-          that.bar.css('top', 0);
+          that.bar.css({ top: 0, bottom: '' });
       }
     };
 
     let _applyCloseOnClick = () => {
       if (that.settings.closeOnClick) {
-        that.bar.click(() => {
+        that.bar.css('cursor', 'pointer').click(() => {
           that.hide();
         });
       }

--- a/src/scss/peekabar.scss
+++ b/src/scss/peekabar.scss
@@ -5,4 +5,5 @@
   left: 0;
   right: 0;
   text-align: center;
+  z-index: 9999;
 }


### PR DESCRIPTION
## Bugs fixed

### 1. Shallow merge breaks nested `animation` options
`$.extend({}, defaults, options)` is a shallow merge. Passing `{ animation: { type: 'fade' } }` would completely replace the default `animation` object, silently dropping `duration: 'slow'`. Changed to `$.extend(true, {}, defaults, options)` for a deep merge.

### 2. `_applyAutohide` fires on init, not on show
`_applyAutohide()` was called during initialization, starting the autohide timer immediately — before `show()` was ever called. The bar would attempt to hide itself even if it was never shown. Removed `_applyAutohide` entirely; autohide is already handled correctly inside `show()`.

### 3. `fadeIn`/`fadeOut` ignore custom `opacity` setting
jQuery's `fadeIn()` always animates to `opacity: 1`. Setting `opacity: 0.7` had no effect when using the `fade` animation type. Replaced `fadeIn`/`fadeOut` with `animate({ opacity })` targeting the user's configured value, and `animate({ opacity: 0 })` followed by `.hide()` on the way out.

### 4. Multiple `show()` calls stack autohide timers
Each call to `show()` added a new `setTimeout` with no way to cancel the previous one. Stored the timer reference in `this._autohideTimer` and call `clearTimeout` before setting a new one.

### 5. `position: 'bottom'` doesn't reset `top` (and vice versa)
`_applyPosition` only set the relevant axis, leaving the opposite axis unset. Now explicitly clears the opposite axis (`top: ''` / `bottom: ''`) to prevent conflicts.

## Improvements

### 6. Missing `z-index` in CSS
The bar had no `z-index`, so it could render behind other fixed/sticky elements such as navbars or modals. Added `z-index: 9999` to `.peek-a-bar`.

### 7. `closeOnClick` had no cursor affordance
When `closeOnClick: true`, the bar was clickable but showed the default cursor. Added `cursor: pointer` so users know the bar is interactive.

### 8. `onShow`/`onHide` callbacks fired before animation completed
Both callbacks were invoked immediately on `show()`/`hide()`, before the slide or fade finished. Any code in these callbacks that reads the bar's dimensions or position would get incorrect values. Moved both callbacks to be passed as the animation completion handler.

### 9. No `destroy()` method
There was no way to remove a bar instance and clean up its DOM node. Repeated instantiation would leak elements. Added `this.destroy()` which cancels any pending autohide timer and removes the bar from the DOM.

### 10. `Math.random()` used for instance IDs
`Math.random() * 100000000` can theoretically produce collisions. Replaced with a module-level monotonic counter (`_instanceCount`) that guarantees unique IDs.

## Files changed

- `src/js/peekabar.js` — all JS fixes and improvements
- `src/scss/peekabar.scss` — added `z-index: 9999`