### PR TITLE
chore: add CLAUDE.md with project rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Rules
+
+## Git
+
+- Never commit or push directly to `master`. Always create a branch and open a PR.


### PR DESCRIPTION
Adds a `CLAUDE.md` to the repo so Claude Code follows project-level rules consistently, regardless of who is running it.

## Rules

- **No direct commits to `master`** — always branch and open a PR.