### PR TITLE
ci: add workflow_dispatch trigger to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,8 +33,6 @@ jobs:
         run: yarn build
       - name: Authenticate with the npm registry
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-      - name: Verify npm token
-        run: npm whoami
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,8 @@ jobs:
         run: yarn build
       - name: Authenticate with the npm registry
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+      - name: Verify npm token
+        run: npm whoami
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags-ignore:
       - '*.*'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,9 @@ jobs:
         run: yarn install
       - name: Create build
         run: yarn build
+      - name: Verify npm token
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          npm whoami
       - name: Release pre-check
         run: npm pack


### PR DESCRIPTION
Adds `workflow_dispatch` to the CD workflow so the release can be manually triggered from the Actions tab without needing to push a commit.

This also serves as the push to `master` needed to kick off the 5.0.0 release that was skipped when the previous re-run saw a stale checkout.