### PR TITLE
fix!: correct breaking change version bump in semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,7 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
+          { "breaking": true, "release": "major" },
           { "type": "chore", "release": "patch" },
           { "type": "refactor", "release": "patch" }
         ]


### PR DESCRIPTION
## Problem

The custom `releaseRules` in `.releaserc.json` were prepended to the preset defaults, and the first matching rule wins. When semantic-release saw the `chore!` commit from PR #181, it matched `{ "type": "chore", "release": "patch" }` first and returned a patch bump — never reaching the default `{ "breaking": true, "release": "major" }` rule. The breaking change appeared in the changelog but didn't influence the version, causing v4.0.26 to be published instead of v5.0.0.

## Fix

Added `{ "breaking": true, "release": "major" }` as the first rule in `releaseRules` so it takes priority over type-based rules for any commit with a `BREAKING CHANGE` footer or `!` in the type.

## This release

This commit itself carries a `BREAKING CHANGE` footer to re-trigger the major version bump with the corrected config in place, releasing v5.0.0. v4.0.26 will be deprecated on npm pointing users to v5.0.0.